### PR TITLE
get card by id and its evidences

### DIFF
--- a/src/modules/card/card.controller.ts
+++ b/src/modules/card/card.controller.ts
@@ -17,4 +17,9 @@ export class CardController {
   findByResponsibleId(@Param('responsibleId') responsibleId: number){
     return this.cardService.findSiteCards(responsibleId)
   }
+
+  @Get('/:cardId')
+  findByIDAndGetEvidences(@Param('cardId') cardId: number){
+    return this.cardService.findCardByIDAndGetEvidences(cardId)
+  }
 }

--- a/src/modules/card/card.module.ts
+++ b/src/modules/card/card.module.ts
@@ -3,9 +3,10 @@ import { CardService } from './card.service';
 import { CardController } from './card.controller';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { CardEntity } from './entities/card.entity';
+import { EvidenceEntity } from '../evidence/entities/evidence.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([CardEntity])],
+  imports: [TypeOrmModule.forFeature([CardEntity, EvidenceEntity])],
   controllers: [CardController],
   providers: [CardService],
 })

--- a/src/modules/card/card.service.ts
+++ b/src/modules/card/card.service.ts
@@ -3,10 +3,12 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { CardEntity } from './entities/card.entity';
 import { Repository } from 'typeorm';
 import { HandleException } from 'src/common/exceptions/handler/handle.exception';
+import { EvidenceEntity } from '../evidence/entities/evidence.entity';
 
 @Injectable()
 export class CardService {
-  constructor(@InjectRepository(CardEntity) private readonly cardRepository: Repository<CardEntity>){}
+  constructor(@InjectRepository(CardEntity) private readonly cardRepository: Repository<CardEntity>,
+  @InjectRepository(EvidenceEntity) private readonly evidenceRepository: Repository<EvidenceEntity>){}
 
   findSiteCards = async (siteId: number) => {
     try{
@@ -22,4 +24,19 @@ export class CardService {
       HandleException.exception(exception)
     }
   }
+
+  findCardByIDAndGetEvidences = async (cardId: number) =>{
+    try{
+      const card = await this.cardRepository.findOneBy({id: cardId})
+      if(card) card['levelName'] = card.areaName
+      const evidences = await this.evidenceRepository.findBy({cardId: cardId})
+
+      return{
+        card,
+        evidences
+      }
+    }catch(exception){
+      HandleException.exception(exception)
+    }
+  } 
 }

--- a/src/modules/evidence/entities/evidence.entity.ts
+++ b/src/modules/evidence/entities/evidence.entity.ts
@@ -1,0 +1,31 @@
+import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
+
+@Entity('evidences')
+export class EvidenceEntity {
+  @PrimaryGeneratedColumn({ type: 'bigint', unsigned: true, name: 'id' })
+  id: number;
+
+  @Column({ type: 'bigint', unsigned: true, name: 'card_id' })
+  cardId: number;
+
+  @Column({ type: 'bigint', unsigned: true, name: 'site_id' })
+  siteId: number;
+
+  @Column({ type: 'varchar', length: 500, name: 'evidence_name' })
+  evidenceName: string;
+
+  @Column({ type: 'char', length: 5, name: 'evidence_type' })
+  evidenceType: string;
+
+  @Column({ type: 'char', length: 1, default: 'A' })
+  status: string;
+
+  @Column({ name: 'created_at', type: 'timestamp', nullable: true })
+  createdAt: Date;
+
+  @Column({ name: 'updated_at', type: 'timestamp', nullable: true })
+  updatedAt: Date;
+
+  @Column({ name: 'deleted_at', type: 'timestamp', nullable: true })
+  deletedAt: Date;
+}


### PR DESCRIPTION
### Feature / Bug Description
get card by id and its evidences

### Solution
evidence entity created and method in card service to return the card info with levelName and all its evidence info

### Notes
....

### Tickets
[WMA-98](https://cdentalcaregroup.atlassian.net/browse/WMA-98)

### Screenshots / Screencasts
![Captura de pantalla 2024-06-19 111548](https://github.com/M2-App/service-m2/assets/133397335/d162c275-8158-43bf-b9ba-167560004b91)
![Captura de pantalla 2024-06-19 111614](https://github.com/M2-App/service-m2/assets/133397335/10f06a2c-0b38-46ca-9826-366282858c70)



[WMA-98]: https://cdentalcaregroup.atlassian.net/browse/WMA-98?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ