### PR TITLE
get cardTypeId in all  preclassifiers response

### DIFF
--- a/src/modules/preclassifier/entities/preclassifier.entity.ts
+++ b/src/modules/preclassifier/entities/preclassifier.entity.ts
@@ -6,7 +6,6 @@ export class PreclassifierEntity {
   @PrimaryGeneratedColumn({ type: 'bigint', unsigned: true })
   id: number;
 
-  @Exclude()
   @Column({ name: 'cardType_id', type: 'bigint', unsigned: true })
   cardTypeId: number;
 


### PR DESCRIPTION
### Feature / Bug Description
get cardTypeId in all  preclassifiers response

### Solution
Remove the exclude in the entity field cardTpyeId

### Notes
...

### Tickets
[WMA-101](https://cdentalcaregroup.atlassian.net/browse/WMA-101)

### Screenshots / Screencasts
![Captura de pantalla 2024-06-19 170805](https://github.com/M2-App/service-m2/assets/133397335/7ee841f5-cb5b-49c4-96a5-17652b874535)



[WMA-101]: https://cdentalcaregroup.atlassian.net/browse/WMA-101?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ