### PR TITLE
create card api service updated

### DIFF
--- a/src/modules/card/card.service.ts
+++ b/src/modules/card/card.service.ts
@@ -15,7 +15,10 @@ import { CardTypesService } from '../cardTypes/cardTypes.service';
 import { PreclassifierService } from '../preclassifier/preclassifier.service';
 import { UsersService } from '../users/users.service';
 import { LevelService } from '../level/level.service';
-import { ValidationException, ValidationExceptionType } from 'src/common/exceptions/types/validation.exception';
+import {
+  ValidationException,
+  ValidationExceptionType,
+} from 'src/common/exceptions/types/validation.exception';
 
 @Injectable()
 export class CardService {
@@ -79,10 +82,14 @@ export class CardService {
 
   create = async (createCardDTO: CreateCardDTO) => {
     try {
-      const cardUUIDisNotUnique = await this.cardRepository.exists({where: {cardUUID: createCardDTO.cardUUID}})
+      const cardUUIDisNotUnique = await this.cardRepository.exists({
+        where: { cardUUID: createCardDTO.cardUUID },
+      });
 
-      if(cardUUIDisNotUnique){
-        throw new ValidationException(ValidationExceptionType.DUPLICATE_CARD_UUID)
+      if (cardUUIDisNotUnique) {
+        throw new ValidationException(
+          ValidationExceptionType.DUPLICATE_CARD_UUID,
+        );
       }
 
       const site = await this.siteService.findById(createCardDTO.siteId);
@@ -119,87 +126,73 @@ export class CardService {
         throw new NotFoundCustomException(NotFoundCustomExceptionType.USER);
       }
 
-      if (createCardDTO.mechanicId) {
-        const mechanic = await this.userService.findById(
-          createCardDTO.mechanicId,
-        );
-        if (!mechanic)
-          throw new NotFoundCustomException(NotFoundCustomExceptionType.USER);
-        createCardDTO.mechanicName = mechanic.name;
-      }
+      var lastInsertedCard = await this.cardRepository.find({
+        order: { id: 'DESC' },
+        take: 1,
+      });
+      const { siteCardId } = lastInsertedCard[0];
 
-      if (createCardDTO.userProvisionalSolutionId) {
-        const userProvisionalSolution = await this.userService.findById(
-          createCardDTO.userProvisionalSolutionId,
-        );
-        if (!userProvisionalSolution)
-          throw new NotFoundCustomException(NotFoundCustomExceptionType.USER);
-        createCardDTO.userProvisionalSolutionName =
-          userProvisionalSolution.name;
-      }
+      const card = await this.cardRepository.create({
+        ...createCardDTO,
+        siteCardId: siteCardId + 1,
+        siteCode: site.siteCode,
+        cardTypeColor: cardType.color,
+        areaName: area.name,
+        level: area.level,
+        superiorId: Number(area.superiorId) === 0 ? area.id : area.superiorId,
+        priorityCode: priority.priorityCode,
+        priorityDescription: priority.priorityDescription,
+        cardTypeMethodology: cardType.cardTypeMethodology,
+        cardTypeMethodologyName: cardType.methodology,
+        cardTypeName: cardType.name,
+        preclassifierCode: preclassifier.preclassifierCode,
+        preclassifierDescription: preclassifier.preclassifierDescription,
+        creatorName: creator.name,
+        responsableName: responsible.name,
+        createdAt: new Date(),
+        cardDueDate: new Date(),
+        commentsAtCardCreation: createCardDTO.comments,
+      });
 
-      if (createCardDTO.userAppProvisionalSolutionId) {
-        const userAppProvisionalSolution = await this.userService.findById(
-          createCardDTO.userAppProvisionalSolutionId,
-        );
-        if (!userAppProvisionalSolution)
-          throw new NotFoundCustomException(NotFoundCustomExceptionType.USER);
-        createCardDTO.userAppProvisionalSolutionName =
-          userAppProvisionalSolution.name;
-      }
+      await this.cardRepository.save(card);
+      lastInsertedCard = await this.cardRepository.find({order: {id: 'DESC'}, take: 1})
+      const cardAssignEvidences = lastInsertedCard[0]
 
-      if (createCardDTO.userDefinitiveSolutionId) {
-        const userDefinitiveSolution = await this.userService.findById(
-          createCardDTO.userDefinitiveSolutionId,
-        );
-        if (!userDefinitiveSolution)
-          throw new NotFoundCustomException(NotFoundCustomExceptionType.USER);
-        createCardDTO.userDefinitiveSolutionName = userDefinitiveSolution.name;
-      }
+      await Promise.all(createCardDTO.evidences.map(async (evidence) => {
+        switch (evidence.type) {
+          case 'AUCR':
+            cardAssignEvidences.evidenceAucr = true;
+            break;
+          case 'VICR':
+            cardAssignEvidences.evidenceVicr = true;
+            break;
+          case 'IMCR':
+            cardAssignEvidences.evidenceImcr = true;
+            break;
+          case 'AUCL':
+            cardAssignEvidences.evidenceAucl = true;
+            break;
+          case 'VICL':
+            cardAssignEvidences.evidenceVicl = true;
+            break;
+          case 'IMCL':
+            cardAssignEvidences.evidenceImcl = true;
+            break;
+        }
+        var evidenceToCreate = await this.evidenceRepository.create({
+          evidenceName: evidence.url,
+          evidenceType: evidence.type,
+          cardId: cardAssignEvidences.id,
+          siteId: site.id,
+          createdAt: new Date()
+        })
+        await this.evidenceRepository.save(evidenceToCreate);
+      }));
 
-      if (createCardDTO.userAppDefinitiveSolutionId) {
-        const userAppDefinitiveSolution = await this.userService.findById(
-          createCardDTO.userAppDefinitiveSolutionId,
-        );
-        if (!userAppDefinitiveSolution)
-          throw new NotFoundCustomException(NotFoundCustomExceptionType.USER);
-        createCardDTO.userAppDefinitiveSolutionName =
-          userAppDefinitiveSolution.name;
-      }
-
-      if (createCardDTO.managerId) {
-        const manager = await this.userService.findById(
-          createCardDTO.managerId,
-        );
-        if (!manager)
-          throw new NotFoundCustomException(NotFoundCustomExceptionType.USER);
-        createCardDTO.managerName = manager.name;
-      }
-
-      const lastInsertedCard = await this.cardRepository.find({order: {id: 'DESC'}, take: 1})
-      const {siteCardId} = lastInsertedCard[0]
-      createCardDTO.siteCardId = siteCardId+1
-      createCardDTO.siteCode = site.siteCode
-      createCardDTO.cardTypeColor = cardType.color
-      createCardDTO.areaName = area.name
-      createCardDTO.level = area.level
-      createCardDTO.superiorId = Number(area.superiorId) === 0 ? area.id: area.superiorId
-      createCardDTO.priorityCode = priority.priorityCode
-      createCardDTO.priorityDescription = priority.priorityDescription
-      createCardDTO.cardTypeMethodology = cardType.cardTypeMethodology
-      createCardDTO.cardTypeMethodologyName = cardType.methodology
-      createCardDTO.cardTypeName = cardType.name
-      createCardDTO.preclassifierCode = preclassifier.preclassifierCode
-      createCardDTO.preclassifierDescription = preclassifier.preclassifierDescription
-      createCardDTO.creatorName = creator.name
-      createCardDTO.responsableName = responsible.name
-      createCardDTO.createdAt = new Date()
-      createCardDTO.cardDueDate = new Date()
-
-     return await this.cardRepository.save(createCardDTO)
+      return await this.cardRepository.save(cardAssignEvidences)
 
     } catch (exception) {
-      console.log(exception)
+      console.log(exception);
       HandleException.exception(exception);
     }
   };

--- a/src/modules/card/card.service.ts
+++ b/src/modules/card/card.service.ts
@@ -19,6 +19,7 @@ import {
   ValidationException,
   ValidationExceptionType,
 } from 'src/common/exceptions/types/validation.exception';
+import { stringConstants } from 'src/utils/string.constant';
 
 @Injectable()
 export class CardService {
@@ -104,9 +105,6 @@ export class CardService {
         createCardDTO.preclassifierId,
       );
       const creator = await this.userService.findById(createCardDTO.creatorId);
-      const responsible = await this.userService.findById(
-        createCardDTO.responsableId,
-      );
 
       if (!site) {
         throw new NotFoundCustomException(NotFoundCustomExceptionType.SITE);
@@ -122,7 +120,7 @@ export class CardService {
         throw new NotFoundCustomException(
           NotFoundCustomExceptionType.PRECLASSIFIER,
         );
-      } else if (!creator || !responsible) {
+      } else if (!creator) {
         throw new NotFoundCustomException(NotFoundCustomExceptionType.USER);
       }
 
@@ -148,7 +146,6 @@ export class CardService {
         preclassifierCode: preclassifier.preclassifierCode,
         preclassifierDescription: preclassifier.preclassifierDescription,
         creatorName: creator.name,
-        responsableName: responsible.name,
         createdAt: new Date(),
         cardDueDate: new Date(),
         commentsAtCardCreation: createCardDTO.comments,
@@ -160,22 +157,22 @@ export class CardService {
 
       await Promise.all(createCardDTO.evidences.map(async (evidence) => {
         switch (evidence.type) {
-          case 'AUCR':
+          case stringConstants.AUCR:
             cardAssignEvidences.evidenceAucr = true;
             break;
-          case 'VICR':
+          case stringConstants.VICR:
             cardAssignEvidences.evidenceVicr = true;
             break;
-          case 'IMCR':
+          case stringConstants.VICR:
             cardAssignEvidences.evidenceImcr = true;
             break;
-          case 'AUCL':
+          case stringConstants.AUCL:
             cardAssignEvidences.evidenceAucl = true;
             break;
-          case 'VICL':
+          case stringConstants.VICL:
             cardAssignEvidences.evidenceVicl = true;
             break;
-          case 'IMCL':
+          case stringConstants.IMCL:
             cardAssignEvidences.evidenceImcl = true;
             break;
         }

--- a/src/modules/card/models/dto/create-card.dto.ts
+++ b/src/modules/card/models/dto/create-card.dto.ts
@@ -1,73 +1,67 @@
-import { IsInt, IsNotEmpty, IsString, IsEnum, IsBoolean, IsDate, IsOptional, IsISO8601 } from 'class-validator';
+import {
+  IsInt,
+  IsNotEmpty,
+  IsString,
+  IsEnum,
+  IsOptional,
+  IsISO8601,
+  IsArray,
+  ValidateNested,
+} from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
-
-enum Feasibility {
-  Alto = 'Alto',
-  Bajo = 'Bajo',
-}
-
-enum Effect {
-  Alto = 'Alto',
-  Bajo = 'Bajo',
-}
+import { Type } from 'class-transformer';
 
 enum CardTypeValue {
   Safe = 'safe',
   Unsafe = 'unsafe',
 }
 
-export class CreateCardDTO {
-  siteCardId?: number;
+enum EvidenceType {
+  IMCR = 'IMCR',
+  IMCL = 'IMCL',
+  IMPS = 'IMPS',
+  VICR = 'VICR',
+  VICL = 'VICL',
+  VIPS = 'VIPS',
+  AUCR = 'AUCR',
+  AUCL = 'AUCL',
+  AUPS = 'AUPS',
+}
 
+class Evidence {
+  @ApiProperty({ description: 'Type of the evidence', enum: EvidenceType })
+  @IsEnum(EvidenceType)
+  @IsNotEmpty()
+  type: EvidenceType;
+
+  @ApiProperty({ description: 'URL of the evidence' })
+  @IsString()
+  @IsNotEmpty()
+  url: string;
+}
+
+export class CreateCardDTO {
   @ApiProperty()
   @IsInt()
   siteId: number;
-
-  siteCode?: string;
 
   @ApiProperty()
   @IsString()
   @IsNotEmpty()
   cardUUID: string;
 
-
-  cardTypeColor?: string;
-
-  @ApiProperty({ enum: ['Alto', 'Bajo'], nullable: true })
-  @IsEnum(Feasibility)
-  @IsOptional()
-  feasibility: Feasibility | null;
-
-  @ApiProperty({ enum: ['Alto', 'Bajo'], nullable: true })
-  @IsEnum(Effect)
-  @IsOptional()
-  effect: Effect | null;
-
-
-  @ApiProperty({type: 'Date', example: '2023-06-20T00:00:00.000Z'})
+  @ApiProperty({ type: 'Date', example: '2023-06-20T00:00:00.000Z' })
   @IsISO8601()
   cardCreationDate: string;
-
-  cardDueDate?: Date;
 
   @ApiProperty({ required: false })
   @IsInt()
   @IsOptional()
   areaId: number | null;
 
-  areaName?: string;
-  level?: number;
-  superiorId?: number;
-
   @ApiProperty()
   @IsInt()
   priorityId: number;
-
-  priorityCode?: string;
-  priorityDescription?: string;
-
-  cardTypeMethodology?: string;
-  cardTypeMethodologyName?: string;
 
   @ApiProperty({ enum: ['safe', 'unsafe'] })
   @IsEnum(CardTypeValue)
@@ -77,124 +71,26 @@ export class CreateCardDTO {
   @IsInt()
   cardTypeId: number;
 
-  cardTypeName?: string;
-
   @ApiProperty()
   @IsInt()
   preclassifierId: number;
-
-  preclassifierCode?: string;
-  preclassifierDescription?: string;
 
   @ApiProperty()
   @IsInt()
   creatorId: number;
 
-  creatorName?: string;
-
   @ApiProperty()
   @IsInt()
   responsableId: number;
 
-  responsableName?: string;
-
-  @ApiProperty({ required: false })
-  @IsInt()
-  @IsOptional()
-  mechanicId: number | null;
-
-  mechanicName?: string;
-
-  @ApiProperty({ required: false })
-  @IsInt()
-  @IsOptional()
-  userProvisionalSolutionId: number | null;
-
-  userProvisionalSolutionName?: string;
-
-  @ApiProperty({ required: false })
-  @IsInt()
-  @IsOptional()
-  userAppProvisionalSolutionId: number | null;
-
-  userAppProvisionalSolutionName: string;
-
-  @ApiProperty({ required: false })
-  @IsInt()
-  @IsOptional()
-  userDefinitiveSolutionId: number | null;
-
-  userDefinitiveSolutionName?: string;
-
-  @ApiProperty({ required: false })
-  @IsInt()
-  @IsOptional()
-  userAppDefinitiveSolutionId: number | null;
-
-  userAppDefinitiveSolutionName?: string;
-
-  @ApiProperty({ required: false })
-  @IsInt()
-  @IsOptional()
-  managerId: number | null;
-
-  managerName?: string;
-
-  @ApiProperty({ required: false, type: 'Date', example: '2023-06-20T00:00:00.000Z'})
-  @IsISO8601()
-  cardManagerCloseDate: string;
-
   @ApiProperty({ required: false })
   @IsString()
   @IsOptional()
-  commentsManagerAtCardClose: string | null;
+  comments: string | null;
 
-  @ApiProperty({ required: false })
-  @IsString()
-  @IsOptional()
-  commentsAtCardCreation: string | null;
-
-  @ApiProperty({ required: false, type: 'Date', example: '2023-06-20T00:00:00.000Z'})
-  @IsISO8601()
-  cardProvisionalSolutionDate: string;
-
-  @ApiProperty({ required: false })
-  @IsString()
-  @IsOptional()
-  commentsAtCardProvisionalSolution: string | null;
-
-  @ApiProperty({ required: false, type: 'Date', example: '2023-06-20T00:00:00.000Z'})
-  @IsISO8601()
-  cardDefinitiveSolutionDate: string;
-
-  @ApiProperty({ required: false })
-  @IsString()
-  @IsOptional()
-  commentsAtCardDefinitiveSolution: string | null;
-
-  @ApiProperty()
-  @IsBoolean()
-  evidenceAucr: boolean;
-
-  @ApiProperty()
-  @IsBoolean()
-  evidenceVicr: boolean;
-
-  @ApiProperty()
-  @IsBoolean()
-  evidenceImcr: boolean;
-
-  @ApiProperty()
-  @IsBoolean()
-  evidenceAucl: boolean;
-
-  @ApiProperty()
-  @IsBoolean()
-  evidenceVicl: boolean;
-
-  @ApiProperty()
-  @IsBoolean()
-  evidenceImcl: boolean;
-
-  createdAt?: Date
+  @ApiProperty({ type: [Evidence] })
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => Evidence)
+  evidences: Evidence[];
 }

--- a/src/modules/card/models/dto/create-card.dto.ts
+++ b/src/modules/card/models/dto/create-card.dto.ts
@@ -78,11 +78,7 @@ export class CreateCardDTO {
   @ApiProperty()
   @IsInt()
   creatorId: number;
-
-  @ApiProperty()
-  @IsInt()
-  responsableId: number;
-
+  
   @ApiProperty({ required: false })
   @IsString()
   @IsOptional()

--- a/src/utils/string.constant.ts
+++ b/src/utils/string.constant.ts
@@ -5,6 +5,14 @@ export const stringConstants = {
   duplicateRole: 'This role already exists',
   duplicateCardUUID: 'The UUID already exists',
 
+  //Types of evidences
+  AUCR: 'AUCR',
+  VICR: 'VICR',
+  IMCR: 'IMCR',
+  AUCL: 'AUCL',
+  VICL: 'VICL',
+  IMCL: 'IMCL',
+
   //status
   activeStatus: 'A',
   inactiveStatus: 'I',


### PR DESCRIPTION
### Feature / Bug Description
create card api service updated

### Solution
create card api service updated

### Notes
The responsible id is requested because is not null in the database.
For now there are only 6 types of evidence validation in the switch cause table Card see the image 1


### Tickets
[WMA-105](https://cdentalcaregroup.atlassian.net/browse/WMA-105)

### Screenshots / Screencasts
image 1
![image](https://github.com/M2-App/service-m2/assets/133397335/1def8686-2c69-470a-8877-3a0891f8e226)
![Captura de pantalla 2024-06-21 170313](https://github.com/M2-App/service-m2/assets/133397335/1d5f0295-902c-4d64-8f01-f8cd8d1e0f00)
![Captura de pantalla 2024-06-21 170328](https://github.com/M2-App/service-m2/assets/133397335/a6607706-e666-4227-9a3a-c96a5dcbdad9)




[WMA-105]: https://cdentalcaregroup.atlassian.net/browse/WMA-105?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ