### PR TITLE
refactor card methodology validation to only valide with C

### DIFF
--- a/src/modules/card/card.service.ts
+++ b/src/modules/card/card.service.ts
@@ -147,11 +147,11 @@ export class CardService {
         priorityCode: priority.priorityCode,
         priorityDescription: priority.priorityDescription,
         cardTypeMethodology:
-          cardType.cardTypeMethodology === stringConstants.M
+          cardType.cardTypeMethodology === stringConstants.C
             ? cardType.cardTypeMethodology
             : null,
         cardTypeValue:
-          cardType.cardTypeMethodology === stringConstants.M
+          cardType.cardTypeMethodology === stringConstants.C
             ? createCardDTO.cardTypeValue
             : null,
         cardTypeMethodologyName: cardType.methodology,

--- a/src/modules/card/models/dto/create-card.dto.ts
+++ b/src/modules/card/models/dto/create-card.dto.ts
@@ -65,7 +65,8 @@ export class CreateCardDTO {
 
   @ApiProperty({ enum: ['safe', 'unsafe'] })
   @IsEnum(CardTypeValue)
-  cardTypeValue: CardTypeValue;
+  @IsOptional()
+  cardTypeValue: CardTypeValue | null;
 
   @ApiProperty()
   @IsInt()


### PR DESCRIPTION
### Feature / Bug Description
refactor card methodology validation to only valide with C
### Solution
refactor card methodology validation to only valide with C

### Notes
no notes needed

### Tickets
[WMA-121](https://cdentalcaregroup.atlassian.net/browse/WMA-121)

### Screenshots / Screencasts
When a card with comportamiento methodology type is created
![Captura de pantalla 2024-07-02 133425](https://github.com/M2-App/service-m2/assets/133397335/65f75d39-a389-4401-942b-0e2a677d1fa9)
When a card without comportamiento methodology type is created
![Captura de pantalla 2024-07-02 133502](https://github.com/M2-App/service-m2/assets/133397335/95c605e8-9c1e-470c-a1f1-b5b47e624b5e)




[WMA-121]: https://cdentalcaregroup.atlassian.net/browse/WMA-121?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ