### PR TITLE
Card evidences indicators now return 1 and 0 when  you create one

### DIFF
--- a/src/modules/card/card.service.ts
+++ b/src/modules/card/card.service.ts
@@ -181,31 +181,31 @@ export class CardService {
         createCardDTO.evidences.map(async (evidence) => {
           switch (evidence.type) {
             case stringConstants.AUCR:
-              cardAssignEvidences.evidenceAucr = true;
+              cardAssignEvidences.evidenceAucr = 1;
               break;
             case stringConstants.VICR:
-              cardAssignEvidences.evidenceVicr = true;
+              cardAssignEvidences.evidenceVicr = 1;
               break;
             case stringConstants.IMCR:
-              cardAssignEvidences.evidenceImcr = true;
+              cardAssignEvidences.evidenceImcr = 1;
               break;
             case stringConstants.AUCL:
-              cardAssignEvidences.evidenceAucl = true;
+              cardAssignEvidences.evidenceAucl = 1;
               break;
             case stringConstants.VICL:
-              cardAssignEvidences.evidenceVicl = true;
+              cardAssignEvidences.evidenceVicl = 1;
               break;
             case stringConstants.IMCL:
-              cardAssignEvidences.evidenceImcl = true;
+              cardAssignEvidences.evidenceImcl = 1;
               break;
             case stringConstants.IMPS:
-              cardAssignEvidences.evidenceImps = true;
+              cardAssignEvidences.evidenceImps = 1;
               break;
             case stringConstants.AUPS:
-              cardAssignEvidences.evidenceAups = true;
+              cardAssignEvidences.evidenceAups = 1;
               break;
             case stringConstants.VIPS:
-              cardAssignEvidences.evidenceVips = true;
+              cardAssignEvidences.evidenceVips = 1;
               break;
           }
           var evidenceToCreate = await this.evidenceRepository.create({
@@ -266,31 +266,31 @@ export class CardService {
         updateDefinitivesolutionDTO.evidences.map(async (evidence) => {
           switch (evidence.type) {
             case stringConstants.AUCR:
-              card.evidenceAucr = true;
+              card.evidenceAucr = 1;
               break;
             case stringConstants.VICR:
-              card.evidenceVicr = true;
+              card.evidenceVicr = 1;
               break;
             case stringConstants.IMCR:
-              card.evidenceImcr = true;
+              card.evidenceImcr = 1;
               break;
             case stringConstants.AUCL:
-              card.evidenceAucl = true;
+              card.evidenceAucl = 1;
               break;
             case stringConstants.VICL:
-              card.evidenceVicl = true;
+              card.evidenceVicl = 1;
               break;
             case stringConstants.IMCL:
-              card.evidenceImcl = true;
+              card.evidenceImcl = 1;
               break;
             case stringConstants.IMPS:
-              card.evidenceImps = true;
+              card.evidenceImps = 1;
               break;
             case stringConstants.AUPS:
-              card.evidenceAups = true;
+              card.evidenceAups = 1;
               break;
             case stringConstants.VIPS:
-              card.evidenceVips = true;
+              card.evidenceVips = 1;
               break;
           }
           var evidenceToCreate = await this.evidenceRepository.create({
@@ -375,31 +375,31 @@ export class CardService {
         updateProvisionalSolutionDTO.evidences.map(async (evidence) => {
           switch (evidence.type) {
             case stringConstants.AUCR:
-              card.evidenceAucr = true;
+              card.evidenceAucr = 1;
               break;
             case stringConstants.VICR:
-              card.evidenceVicr = true;
+              card.evidenceVicr = 1;
               break;
             case stringConstants.IMCR:
-              card.evidenceImcr = true;
+              card.evidenceImcr = 1;
               break;
             case stringConstants.AUCL:
-              card.evidenceAucl = true;
+              card.evidenceAucl = 1;
               break;
             case stringConstants.VICL:
-              card.evidenceVicl = true;
+              card.evidenceVicl = 1;
               break;
             case stringConstants.IMCL:
-              card.evidenceImcl = true;
+              card.evidenceImcl = 1;
               break;
             case stringConstants.IMPS:
-              card.evidenceImps = true;
+              card.evidenceImps = 1;
               break;
             case stringConstants.AUPS:
-              card.evidenceAups = true;
+              card.evidenceAups = 1;
               break;
             case stringConstants.VIPS:
-              card.evidenceVips = true;
+              card.evidenceVips = 1;
               break;
           }
           var evidenceToCreate = await this.evidenceRepository.create({

--- a/src/modules/card/entities/card.entity.ts
+++ b/src/modules/card/entities/card.entity.ts
@@ -337,7 +337,7 @@ export class CardEntity {
     default: () => '0',
     name: 'evidence_aucr',
   })
-  evidenceAucr: boolean;
+  evidenceAucr: number;
 
   @Column({
     type: 'tinyint',
@@ -346,7 +346,7 @@ export class CardEntity {
     default: () => '0',
     name: 'evidence_vicr',
   })
-  evidenceVicr: boolean;
+  evidenceVicr: number;
 
   @Column({
     type: 'tinyint',
@@ -355,7 +355,7 @@ export class CardEntity {
     default: () => '0',
     name: 'evidence_imcr',
   })
-  evidenceImcr: boolean;
+  evidenceImcr: number;
 
   @Column({
     type: 'tinyint',
@@ -364,7 +364,7 @@ export class CardEntity {
     default: () => '0',
     name: 'evidence_aucl',
   })
-  evidenceAucl: boolean;
+  evidenceAucl: number;
 
   @Column({
     type: 'tinyint',
@@ -373,7 +373,7 @@ export class CardEntity {
     default: () => '0',
     name: 'evidence_vicl',
   })
-  evidenceVicl: boolean;
+  evidenceVicl: number;
 
   @Column({
     type: 'tinyint',
@@ -382,7 +382,7 @@ export class CardEntity {
     default: () => '0',
     name: 'evidence_imcl',
   })
-  evidenceImcl: boolean;
+  evidenceImcl: number;
 
   @Column({ name: 'created_at', type: 'timestamp', nullable: true })
   createdAt: Date;
@@ -400,7 +400,7 @@ export class CardEntity {
     default: () => '0',
     name: 'evidence_aups',
   })
-  evidenceAups: boolean;
+  evidenceAups: number;
 
   @Column({
     type: 'tinyint',
@@ -409,7 +409,7 @@ export class CardEntity {
     default: () => '0',
     name: 'evidence_vips',
   })
-  evidenceVips: boolean;
+  evidenceVips: number;
 
   @Column({
     type: 'tinyint',
@@ -418,5 +418,5 @@ export class CardEntity {
     default: () => '0',
     name: 'evidence_imps',
   })
-  evidenceImps: boolean;
+  evidenceImps: number;
 }


### PR DESCRIPTION
### Feature / Bug Description
Card evidences indicators now return 1 and 0 when  you create one

### Solution
Card evidences indicators now return 1 and 0 when  you create one

Card evidences indicators now return 1 and 0 when  you create one

### Tickets
[WMA-122](https://cdentalcaregroup.atlassian.net/browse/WMA-122)

### Screenshots / Screencasts
![Captura de pantalla 2024-07-05 142316](https://github.com/M2-App/service-m2/assets/133397335/ec2acc15-9752-435d-ae0e-e67a1dfbb73c)



[WMA-122]: https://cdentalcaregroup.atlassian.net/browse/WMA-122?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ