### PR TITLE
Changes in the incremental card_site_id

### DIFF
--- a/src/modules/card/card.service.ts
+++ b/src/modules/card/card.service.ts
@@ -23,7 +23,6 @@ import { stringConstants } from 'src/utils/string.constant';
 import { UpdateDefinitiveSolutionDTO } from './models/dto/update.definitive.solution.dto';
 import { CardNoteEntity } from '../cardNotes/card.notes.entity';
 import { UpdateProvisionalSolutionDTO } from './models/dto/update.provisional.solution.dto';
-import { PreclassifierEntity } from '../preclassifier/entities/preclassifier.entity';
 import { PriorityEntity } from '../priority/entities/priority.entity';
 
 @Injectable()
@@ -134,16 +133,15 @@ export class CardService {
         throw new NotFoundCustomException(NotFoundCustomExceptionType.USER);
       }
 
-      var lastInsertedCard = await this.cardRepository.find({
+      var lastInsertedCard;
+      lastInsertedCard = await this.cardRepository.findOne({
         order: { id: 'DESC' },
-        take: 1,
+        where: { siteId: site.id },
       });
 
       const card = await this.cardRepository.create({
         ...createCardDTO,
-        siteCardId: lastInsertedCard[0]
-          ? lastInsertedCard[0].siteCardId + 1
-          : 1,
+        siteCardId: lastInsertedCard ? lastInsertedCard.siteCardId + 1 : 1,
         siteCode: site.siteCode,
         cardTypeColor: cardType.color,
         areaName: area.name,


### PR DESCRIPTION
### Feature / Bug Description
Changes in the incremental card_site_id

### Solution
Now the 'card_site_id' increases in accordance with the cards of a site
 
### Notes
Add some notes

### Tickets
[WMA-126](https://cdentalcaregroup.atlassian.net/browse/WMA-126)

### Screenshots / Screencasts
Check how when you insert a card now the increment number is accordance with the last number for a specific site 
![image](https://github.com/M2-App/service-m2/assets/133397335/64469754-72be-4b60-adb1-492ea4918bc1)
![Captura de pantalla 2024-07-08 151030](https://github.com/M2-App/service-m2/assets/133397335/1607a5cc-5bfd-417f-b5b2-fccbd1c1b89c)



[WMA-126]: https://cdentalcaregroup.atlassian.net/browse/WMA-126?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ