### PR TITLE
get card by superior Id and site Id

### DIFF
--- a/src/modules/card/card.controller.ts
+++ b/src/modules/card/card.controller.ts
@@ -1,4 +1,13 @@
-import { Controller, Get, Post, Body, Patch, Param, Delete, Put } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Patch,
+  Param,
+  Delete,
+  Put,
+} from '@nestjs/common';
 import { CardService } from './card.service';
 import { ApiParam, ApiTags } from '@nestjs/swagger';
 import { CreateCardDTO } from './models/dto/create-card.dto';
@@ -11,36 +20,48 @@ export class CardController {
   constructor(private readonly cardService: CardService) {}
 
   @Get('/all/:siteId')
-  @ApiParam({name: 'siteId'})
-  findBySiteId(@Param('siteId') siteId: number){
-    return this.cardService.findSiteCards(siteId)
+  @ApiParam({ name: 'siteId' })
+  findBySiteId(@Param('siteId') siteId: number) {
+    return this.cardService.findSiteCards(siteId);
   }
   @Get('/responsible/:responsibleId')
-  @ApiParam({name: 'responsibleId'})
-  findByResponsibleId(@Param('responsibleId') responsibleId: number){
-    return this.cardService.findSiteCards(responsibleId)
+  @ApiParam({ name: 'responsibleId' })
+  findByResponsibleId(@Param('responsibleId') responsibleId: number) {
+    return this.cardService.findSiteCards(responsibleId);
   }
 
   @Get('/:cardId')
-  findByIDAndGetEvidences(@Param('cardId') cardId: number){
-    return this.cardService.findCardByIDAndGetEvidences(cardId)
+  findByIDAndGetEvidences(@Param('cardId') cardId: number) {
+    return this.cardService.findCardByIDAndGetEvidences(cardId);
   }
 
   @Post('/create')
-  create(@Body() createCardDTO: CreateCardDTO){
-    return this.cardService.create(createCardDTO)
+  create(@Body() createCardDTO: CreateCardDTO) {
+    return this.cardService.create(createCardDTO);
   }
   @Put('/update/definitive-solution')
-  updateDefinitiveSolution(@Body() updateDefinitiveSolutionDTO: UpdateDefinitiveSolutionDTO){
-    return this.cardService.updateDefinitivesolution(updateDefinitiveSolutionDTO)
+  updateDefinitiveSolution(
+    @Body() updateDefinitiveSolutionDTO: UpdateDefinitiveSolutionDTO,
+  ) {
+    return this.cardService.updateDefinitivesolution(
+      updateDefinitiveSolutionDTO,
+    );
   }
   @Put('/update/provisional-solution')
-  updateProvisionalSolution(@Body() updateProvisionalSolutionDTO: UpdateProvisionalSolutionDTO){
-    return this.cardService.updateProvisionalSolution(updateProvisionalSolutionDTO)
+  updateProvisionalSolution(
+    @Body() updateProvisionalSolutionDTO: UpdateProvisionalSolutionDTO,
+  ) {
+    return this.cardService.updateProvisionalSolution(
+      updateProvisionalSolutionDTO,
+    );
   }
-  @Get('/all/zone/:superiorId')
-  @ApiParam({name: 'superiorId'})
-  getCardsZone(@Param('superiorId') superiorId: number){
-    return this.cardService.getCardBySuperiorId(superiorId)
+  @Get('/all/zone/:superiorId/:siteId')
+  @ApiParam({ name: 'superiorId' })
+  @ApiParam({ name: 'siteId' })
+  getCardsZone(
+    @Param('superiorId') superiorId: number,
+    @Param('siteId') siteId: number,
+  ) {
+    return this.cardService.getCardBySuperiorId(superiorId, siteId);
   }
 }

--- a/src/modules/card/card.service.ts
+++ b/src/modules/card/card.service.ts
@@ -320,11 +320,12 @@ export class CardService {
       HandleException.exception(exception);
     }
   };
-  getCardBySuperiorId = async (superiorId: number) => {
+  getCardBySuperiorId = async (superiorId: number, siteId: number) => {
     try {
       return await this.cardRepository.find({
         where: {
           superiorId: superiorId,
+          siteId: siteId,
           status: In([stringConstants.A, stringConstants.P, stringConstants.V]),
           deletedAt: null,
         },


### PR DESCRIPTION
### Feature / Bug Description
Get card by superior Id and site Id

### Solution
The controller now receives two params, the first is the superior Id and the second is the site Id
changes in Card service and controller to filter by both parameters

### Notes
no notes needed

### Tickets
[WMA-125](https://cdentalcaregroup.atlassian.net/browse/WMA-125)

### Screenshots / Screencasts
![image](https://github.com/M2-App/service-m2/assets/133397335/767ebc22-2edb-44c0-8249-0e2be0d06516)


[WMA-125]: https://cdentalcaregroup.atlassian.net/browse/WMA-125?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ