### PR TITLE
All get cards services now return a lelveList string array

### DIFF
--- a/src/modules/card/card.controller.ts
+++ b/src/modules/card/card.controller.ts
@@ -27,7 +27,7 @@ export class CardController {
   @Get('/responsible/:responsibleId')
   @ApiParam({ name: 'responsibleId' })
   findByResponsibleId(@Param('responsibleId') responsibleId: number) {
-    return this.cardService.findSiteCards(responsibleId);
+    return this.cardService.findResponsibleCards(responsibleId);
   }
 
   @Get('/:cardId')

--- a/src/modules/card/card.service.ts
+++ b/src/modules/card/card.service.ts
@@ -46,9 +46,14 @@ export class CardService {
     try {
       const cards = await this.cardRepository.findBy({ siteId: siteId });
       if (cards) {
-        cards.forEach((card) => {
+        const levelMap = await this.levelService.findAllLevels();
+        for (const card of cards) {
           card['levelName'] = card.areaName;
-        });
+          card['levelList'] = this.levelService.findAllSuperiorLevelsById(
+            String(card.areaId),
+            levelMap,
+          );
+        }
       }
       return cards;
     } catch (exception) {
@@ -61,9 +66,14 @@ export class CardService {
         responsableId: responsibleId,
       });
       if (cards) {
-        cards.forEach((card) => {
+        const levelMap = await this.levelService.findAllLevels();
+        for (const card of cards) {
           card['levelName'] = card.areaName;
-        });
+          card['levelList'] = this.levelService.findAllSuperiorLevelsById(
+            String(card.areaId),
+            levelMap,
+          );
+        }
       }
       return cards;
     } catch (exception) {
@@ -73,7 +83,14 @@ export class CardService {
   findCardByIDAndGetEvidences = async (cardId: number) => {
     try {
       const card = await this.cardRepository.findOneBy({ id: cardId });
-      if (card) card['levelName'] = card.areaName;
+      if (card) {
+        const levelMap = await this.levelService.findAllLevels();
+        card['levelName'] = card.areaName;
+        card['levelList'] = this.levelService.findAllSuperiorLevelsById(
+          String(card.areaId),
+          levelMap,
+        );
+      }
       const evidences = await this.evidenceRepository.findBy({
         cardId: cardId,
       });
@@ -83,6 +100,7 @@ export class CardService {
         evidences,
       };
     } catch (exception) {
+      console.log(exception);
       HandleException.exception(exception);
     }
   };
@@ -320,7 +338,7 @@ export class CardService {
   };
   getCardBySuperiorId = async (superiorId: number, siteId: number) => {
     try {
-      return await this.cardRepository.find({
+      const cards = await this.cardRepository.find({
         where: {
           superiorId: superiorId,
           siteId: siteId,
@@ -328,6 +346,18 @@ export class CardService {
           deletedAt: null,
         },
       });
+      if (cards) {
+        const levelMap = await this.levelService.findAllLevels();
+        for (const card of cards) {
+          card['levelName'] = card.areaName;
+          card['levelList'] = this.levelService.findAllSuperiorLevelsById(
+            String(card.areaId),
+            levelMap,
+          );
+        }
+      }
+
+      return cards;
     } catch (exception) {
       HandleException.exception(exception);
     }


### PR DESCRIPTION
### Feature / Bug Description
All get cards services now return a lelveList string array

### Solution
Create another method to return all the levels and return a Map to avoid some calls to the database, then we get the levelname with another method that filters the Map level by id.

### Notes
no notes needed

### Tickets
[WMA-133](https://cdentalcaregroup.atlassian.net/browse/WMA-133)

### Screenshots / Screencasts
![Captura de pantalla 2024-07-17 131329](https://github.com/user-attachments/assets/f3f8117d-e18e-4c86-90fa-6ec55cdb4f21)



[WMA-133]: https://cdentalcaregroup.atlassian.net/browse/WMA-133?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ