### PR TITLE
get evidences in get site cards

### DIFF
--- a/src/modules/card/card.service.ts
+++ b/src/modules/card/card.service.ts
@@ -47,12 +47,23 @@ export class CardService {
       const cards = await this.cardRepository.findBy({ siteId: siteId });
       if (cards) {
         const levelMap = await this.levelService.findAllLevels();
+        const allEvidencesMap = await this.findAllEvidences();
+
+        const cardEvidencesMap = new Map();
+        allEvidencesMap.forEach((evidence) => {
+          if (!cardEvidencesMap.has(evidence.cardId)) {
+            cardEvidencesMap.set(evidence.cardId, []);
+          }
+          cardEvidencesMap.get(evidence.cardId).push(evidence);
+        });
+
         for (const card of cards) {
           card['levelName'] = card.areaName;
           card['levelList'] = this.levelService.findAllSuperiorLevelsById(
             String(card.areaId),
             levelMap,
           );
+          card['evidences'] = cardEvidencesMap.get(card.id) || [];
         }
       }
       return cards;
@@ -457,5 +468,12 @@ export class CardService {
     } catch (exception) {
       HandleException.exception(exception);
     }
+  };
+
+  findAllEvidences = async () => {
+    const evidences = await this.evidenceRepository.find();
+    const evidencesMap = new Map();
+    evidences.forEach((level) => evidencesMap.set(level.id, level));
+    return evidencesMap;
   };
 }


### PR DESCRIPTION
### Feature / Bug Description
get evidences in get site cards

### Solution
First get all evidences to avoid multiple calls to the database and then set a Map to Maping with its card id

### Notes
I need the evidences in here because now in the frontend there are indicators when there are image or audios etc

### Tickets
[WMA-115](https://cdentalcaregroup.atlassian.net/browse/WMA-115)

### Screenshots / Screencasts
no image needed

[WMA-115]: https://cdentalcaregroup.atlassian.net/browse/WMA-115?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ