### PR TITLE
delete card 'cahnge status'

### DIFF
--- a/src/modules/cardTypes/cardTypes.controller.ts
+++ b/src/modules/cardTypes/cardTypes.controller.ts
@@ -13,30 +13,36 @@ export class CardTypesController {
 
   @Get('/all/:siteId')
   @ApiParam({ name: 'siteId', required: true, example: 1 })
-  findCardTypesByCompany(@Param('siteId') siteId: number) {
+  findActiveCardTypesBySite(@Param('siteId') siteId: number) {
+    return this.cardTypesService.findSiteActiveCardTypes(siteId);
+  }
+
+  @Get('/site/:siteId')
+  @ApiParam({ name: 'siteId', required: true, example: 1 })
+  findCardTypesBySite(@Param('siteId') siteId: number) {
     return this.cardTypesService.findSiteCardTypes(siteId);
   }
 
   @Post('/create')
-  @ApiBody({type: CreateCardTypesDTO})
-  create(@Body() createCardTypesDTO:CreateCardTypesDTO){
-    return this.cardTypesService.create(createCardTypesDTO)
+  @ApiBody({ type: CreateCardTypesDTO })
+  create(@Body() createCardTypesDTO: CreateCardTypesDTO) {
+    return this.cardTypesService.create(createCardTypesDTO);
   }
 
   @Put('/update')
-  @ApiBody({type: UpdateCardTypesDTO})
-  update(@Body() updateCardTypesDTO: UpdateCardTypesDTO){
-    return this.cardTypesService.update(updateCardTypesDTO)
+  @ApiBody({ type: UpdateCardTypesDTO })
+  update(@Body() updateCardTypesDTO: UpdateCardTypesDTO) {
+    return this.cardTypesService.update(updateCardTypesDTO);
   }
 
   @Get('/card-type/:id')
   @ApiParam({ name: 'id', required: true, example: 1 })
   findoneById(@Param('id') id: number) {
-    return this.cardTypesService.findById(id)
+    return this.cardTypesService.findById(id);
   }
 
   @Get('/catalogs')
   findCardTypesCatalogs() {
-    return this.cardTypesService.findAllCatalogs()
+    return this.cardTypesService.findAllCatalogs();
   }
 }

--- a/src/modules/cardTypes/cardTypes.service.ts
+++ b/src/modules/cardTypes/cardTypes.service.ts
@@ -12,6 +12,7 @@ import { CreateCardTypesDTO } from './dto/create.cardTypes.dto';
 import { UpdateCardTypesDTO } from './dto/update.cardTypes.dto';
 import { SiteService } from '../site/site.service';
 import { CardTypesCatalogEntity } from './entities/card.types.catalog.entity';
+import { stringConstants } from 'src/utils/string.constant';
 
 @Injectable()
 export class CardTypesService {
@@ -23,6 +24,17 @@ export class CardTypesService {
     @InjectRepository(CardTypesCatalogEntity)
     private readonly cardTypesCatalogRepository: Repository<CardTypesCatalogEntity>,
   ) {}
+
+  findSiteActiveCardTypes = async (siteId: number) => {
+    try {
+      return await this.cardTypesRepository.findBy({
+        siteId: siteId,
+        status: stringConstants.A,
+      });
+    } catch (exception) {
+      HandleException.exception(exception);
+    }
+  };
 
   findSiteCardTypes = async (siteId: number) => {
     try {
@@ -117,6 +129,9 @@ export class CardTypesService {
       foundCardTpyes.videosDurationPs = updateCardTypesDTO.videosDurationPs;
 
       foundCardTpyes.status = updateCardTypesDTO.status;
+      if (updateCardTypesDTO.status !== stringConstants.A) {
+        foundCardTpyes.deletedAt = new Date();
+      }
       foundCardTpyes.updatedAt = new Date();
 
       return await this.cardTypesRepository.save(foundCardTpyes);

--- a/src/modules/cardTypes/dto/update.cardTypes.dto.ts
+++ b/src/modules/cardTypes/dto/update.cardTypes.dto.ts
@@ -164,33 +164,53 @@ export class UpdateCardTypesDTO {
   @IsOptional()
   videosDurationClose?: number;
 
-  @ApiProperty({ description: 'Quantity of pictures per session', example: 5, required: false })
+  @ApiProperty({
+    description: 'Quantity of pictures per session',
+    example: 5,
+    required: false,
+  })
   @IsOptional()
   @IsInt()
   @Min(0)
   @Max(255)
   quantityPicturesPs?: number;
 
-  @ApiProperty({ description: 'Quantity of audios per session', example: 3, required: false })
+  @ApiProperty({
+    description: 'Quantity of audios per session',
+    example: 3,
+    required: false,
+  })
   @IsOptional()
   @IsInt()
   @Min(0)
   @Max(255)
   quantityAudiosPs?: number;
 
-  @ApiProperty({ description: 'Quantity of videos per session', example: 2, required: false })
+  @ApiProperty({
+    description: 'Quantity of videos per session',
+    example: 2,
+    required: false,
+  })
   @IsOptional()
   @IsInt()
   @Min(0)
   @Max(255)
   quantityVideosPs?: number;
 
-  @ApiProperty({ description: 'Total duration of audios per session in seconds', example: 120, required: false })
+  @ApiProperty({
+    description: 'Total duration of audios per session in seconds',
+    example: 120,
+    required: false,
+  })
   @IsOptional()
   @IsInt()
   audiosDurationPs?: number;
 
-  @ApiProperty({ description: 'Total duration of videos per session in seconds', example: 300, required: false })
+  @ApiProperty({
+    description: 'Total duration of videos per session in seconds',
+    example: 300,
+    required: false,
+  })
   @IsOptional()
   @IsInt()
   videosDurationPs?: number;
@@ -198,12 +218,10 @@ export class UpdateCardTypesDTO {
   @ApiProperty({
     description: 'Status',
     required: true,
-    example: 'A or I',
     minimum: 1,
   })
   @IsNotEmpty()
   @IsString()
-  @IsIn([stringConstants.activeStatus, stringConstants.inactiveStatus])
   status: string;
 
   updatedAt?: Date;


### PR DESCRIPTION
### Feature / Bug Description
Change status of card type

### Solution
Now in the when you update a card type and set status different from 'A' the 'deletedAt' column is filled
Change the restriction of status field in the update DTO
The method to get all card type by site Id now returns all the active cards
Was created another method to return both active and inactive cards;

### Notes
no notes needed

### Tickets
[WMA-139](https://cdentalcaregroup.atlassian.net/browse/WMA-139)

### Screenshots / Screencasts
no image needed

[WMA-139]: https://cdentalcaregroup.atlassian.net/browse/WMA-139?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ