### PR TITLE
Get cards by level mchine id

### DIFF
--- a/src/modules/card/card.controller.ts
+++ b/src/modules/card/card.controller.ts
@@ -1,11 +1,4 @@
-import {
-  Controller,
-  Get,
-  Post,
-  Body,
-  Param,
-  Put,
-} from '@nestjs/common';
+import { Controller, Get, Post, Body, Param, Put } from '@nestjs/common';
 import { CardService } from './card.service';
 import { ApiParam, ApiTags } from '@nestjs/swagger';
 import { CreateCardDTO } from './models/dto/create-card.dto';
@@ -16,6 +9,15 @@ import { UpdateProvisionalSolutionDTO } from './models/dto/update.provisional.so
 @ApiTags('card')
 export class CardController {
   constructor(private readonly cardService: CardService) {}
+
+  @Get('/all/level-machine/:siteId/:levelMachineId')
+  @ApiParam({ name: 'siteId' })
+  findByLevelMachineId(
+    @Param('siteId') siteId: number,
+    @Param('levelMachineId') levelMachineId: string,
+  ) {
+    return this.cardService.findByLevelMachineId(siteId, levelMachineId);
+  }
 
   @Get('/all/:siteId')
   @ApiParam({ name: 'siteId' })

--- a/src/modules/card/card.service.ts
+++ b/src/modules/card/card.service.ts
@@ -48,6 +48,19 @@ export class CardService {
     private readonly firebaseService: FirebaseService,
   ) {}
 
+  findByLevelMachineId = async (siteId: number, levelMachineId: string) => {
+    try {
+      const level = await this.levelService.findByLeveleMachineId(
+        siteId,
+        levelMachineId,
+      );
+
+      return await this.cardRepository.findBy({ areaId: level.id });
+    } catch (exception) {
+      HandleException.exception(exception);
+    }
+  };
+
   findCardByUUID = async (uuid: string) => {
     try {
       const card = await this.cardRepository.findOneBy({ cardUUID: uuid });

--- a/src/modules/level/level.service.ts
+++ b/src/modules/level/level.service.ts
@@ -29,6 +29,17 @@ export class LevelService {
     private readonly firebaseService: FirebaseService,
   ) {}
 
+  findByLeveleMachineId = async (siteId: number, levelMachineId: string) => {
+    try {
+      return await this.levelRepository.findOneBy({
+        siteId: siteId,
+        levelMachineId: levelMachineId,
+      });
+    } catch (exception) {
+      HandleException.exception(exception);
+    }
+  };
+
   findSiteActiveLevels = async (siteId: number) => {
     try {
       return await this.levelRepository.findBy({


### PR DESCRIPTION
### Feature / Bug Description
Get cards by level mchine id

### Solution
Service to return a level by siteId and levelMachineId and then use its id to return a card with that areaId

### Notes
no notes needed

### Tickets
[WMA-158](https://cdentalcaregroup.atlassian.net/browse/WMA-158)

### Screenshots / Screencasts
This site does not have any cards but is the only that has a level with level_machine_id not null
![Captura de pantalla 2024-08-15 124651](https://github.com/user-attachments/assets/f878a0f5-4de9-4849-aa91-57a810a8ad72)



[WMA-158]: https://cdentalcaregroup.atlassian.net/browse/WMA-158?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ