### PR TITLE
nodeId instead of areaId in card findByLevelMachineId service

### DIFF
--- a/src/modules/card/card.service.ts
+++ b/src/modules/card/card.service.ts
@@ -57,7 +57,11 @@ export class CardService {
         levelMachineId,
       );
 
-      return await this.cardRepository.findBy({ areaId: level.id });
+      if (!level) {
+        throw new NotFoundCustomException(NotFoundCustomExceptionType.LEVELS);
+      }
+
+      return await this.cardRepository.findBy({ nodeId: level.id });
     } catch (exception) {
       HandleException.exception(exception);
     }


### PR DESCRIPTION
### Feature / Bug Description
nodeId instead of areaId in card findByLevelMachineId service

### Solution
nodeId instead of areaId in card findByLevelMachineId service
### Notes
no notes needed

### Tickets
[WMA-161](https://cdentalcaregroup.atlassian.net/browse/WMA-161)

### Screenshots / Screencasts
no image needed


[WMA-161]: https://cdentalcaregroup.atlassian.net/browse/WMA-161?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ